### PR TITLE
Update tests

### DIFF
--- a/core/device/adb.py
+++ b/core/device/adb.py
@@ -119,10 +119,7 @@ class Adb(object):
         :param path: Path relative to root folder of the package.
         :return: List of files and folders
         """
-        if 'emu' in device_id:
-            command = 'shell ls -la /data/data/{0}/files/{1}'.format(package_id, path)
-        else:
-            command = 'shell run-as {0} ls -la /data/data/{1}/files/{2}'.format(package_id, package_id, path)
+        command = 'shell run-as {0} ls -la /data/data/{1}/files/{2}'.format(package_id, package_id, path)
         output = Adb.run(command=command, device_id=device_id, log_level=CommandLogLevel.FULL)
         return output
 

--- a/core/osutils/command.py
+++ b/core/osutils/command.py
@@ -79,13 +79,12 @@ def run(command, timeout=COMMAND_TIMEOUT, output=True, wait=True, log_level=Comm
     # wait for thread to finish or timeout
     thread.join(timeout)
 
-    # kill thread
+    # kill thread if it exceed the timeout
     if thread.is_alive():
         if wait:
-            if log_level is not CommandLogLevel.SILENT:
-                print '##### ERROR: Process has timed out at ', time.strftime("%X")
             Process.kill('node')
             thread.join()
+            raise NameError('Process has timed out at ' + time.strftime("%X"))
 
     # get whenever exist in the pipe ?
     pipe_output = 'NOT_COLLECTED'

--- a/tests/simulator/run_ios_tests.py
+++ b/tests/simulator/run_ios_tests.py
@@ -139,7 +139,6 @@ class RunIOSSimulatorTests(BaseClass):
         Device.screen_match(device_type=DeviceType.SIMULATOR, device_name=SIMULATOR_NAME,
                             device_id=self.SIMULATOR_ID, expected_image='livesync-hello-world_home')
 
-    @unittest.skip("Ignored because of https://github.com/NativeScript/nativescript-cli/issues/2653")
     def test_210_tns_run_ios_add_remove_files_and_folders(self):
         """
         New files and folders should be synced properly.
@@ -205,7 +204,6 @@ class RunIOSSimulatorTests(BaseClass):
         Device.screen_match(device_type=DeviceType.SIMULATOR, device_name=SIMULATOR_NAME,
                             device_id=self.SIMULATOR_ID, expected_image='livesync-hello-world_home')
 
-    @unittest.skip('Ignored because of https://github.com/NativeScript/nativescript-cli/issues/2654')
     def test_300_tns_run_ios_just_launch_and_incremental_builds(self):
         """
         This test verify following things:
@@ -235,7 +233,7 @@ class RunIOSSimulatorTests(BaseClass):
         ReplaceHelper.replace(self.app_name, ReplaceHelper.CHANGE_XML)
 
         # Run `tns run android` after file changes (this should trigger incremental prepare).
-        output = Tns.run_ios(attributes={'--path': self.app_name, '--justlaunch': ''}, assert_success=False, timeout=30)
+        output = Tns.run_ios(attributes={'--path': self.app_name, '--justlaunch': ''}, assert_success=False, timeout=60)
         TnsAsserts.prepared(app_name=self.app_name, platform=Platform.IOS, output=output, prepare=Prepare.INCREMENTAL)
 
         # Verify app looks is update after changes in js, css and xml


### PR DESCRIPTION
1. Enable tests after bug fixes:
  - `test_210_tns_run_ios_add_remove_files_and_folders`
  - `test_300_tns_run_ios_just_launch_and_incremental_builds after bug`

2. Raise error when `run` command exceed timeout:
  - This will ensure `test_300_tns_run_ios_just_launch_and_incremental_builds` won't be false green when `--justlaunch` fails.

3. Always use 'run-as' when read application files with adb:
  - Api25 emulators also require `run-as`